### PR TITLE
Tests

### DIFF
--- a/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
+++ b/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
@@ -62,6 +62,7 @@ function Get-SecretInfo {
 
     $json = & op list items --categories Login,Password --vault $VaultName
     $items = $json -replace 'b5UserUUID','B5UserUUID' | ConvertFrom-Json
+    $items = $items | Where-Object {$_.overview.title -like $Filter}
 
     $keyList = [Collections.ArrayList]::new()
 

--- a/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
+++ b/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
@@ -152,7 +152,7 @@ function Set-Secret {
 
     Write-Verbose "Secret type [$($Secret.GetType().Name)]"
     switch ($Secret.GetType()) {
-        { $_.IsValueType } {
+        { $_.Name -eq 'String' -or $_.IsValueType } {
             $category = "Password"
             Write-Verbose "Processing [string] as $category"
             $commandArgs.Add($verb) | Out-Null

--- a/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
+++ b/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
@@ -60,7 +60,8 @@ function Get-SecretInfo {
         [hashtable] $AdditionalParameters
     )
 
-    $items = & op list items --categories Login,Password --vault $VaultName | ConvertFrom-Json
+    $json = & op list items --categories Login,Password --vault $VaultName
+    $items = $json -replace 'b5UserUUID','B5UserUUID' | ConvertFrom-Json
 
     $keyList = [Collections.ArrayList]::new()
 

--- a/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
+++ b/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
@@ -221,7 +221,7 @@ function Set-Secret {
                 Write-Verbose "Updating $item"
                 $commandArgs.Add($item) | Out-Null
                 $commandArgs.Add("username=$($Secret.UserName)") | Out-Null
-                $commandArgs.Add("password=$(ConvertFrom-SecureString -SecureString $Secret -AsPlainText)") | Out-Null
+                $commandArgs.Add("password=$(ConvertFrom-SecureString -SecureString $Secret.Password -AsPlainText)") | Out-Null
             }
             break
         }

--- a/build.ps1
+++ b/build.ps1
@@ -16,7 +16,7 @@ param (
 Push-Location $PSScriptRoot
 
 if ($Test) {
-    Invoke-Pester test
+    Invoke-Pester tests
 }
 
 if ($Package) {

--- a/tests/Get-Secret.Tests.ps1
+++ b/tests/Get-Secret.Tests.ps1
@@ -69,3 +69,24 @@ Describe 'It gets passwords with vault specified' {
 		if ($createdPassword) {& op delete item $testDetails.PasswordName}
 	}
 }
+
+Describe 'It gets one-time passwords with vault specified' {
+	BeforeAll {
+		# Relies on an item called TOTPTest with TOTP set up being present
+		# TODO: How to create TOTP using op?
+		$TOTPName = 'TOTPTest'
+	}
+
+	It 'Gets a TOTP' {
+		Get-Secret -Vault $testDetails.Vault -Name $TOTPName |
+		Get-Member -MemberType ScriptMethod |
+		Select-Object -ExpandProperty Name |
+		Should -Contain 'totp'
+	}
+
+	It 'Gets the TOTP with vault specified' {
+		$secret = Get-Secret -Vault $testDetails.Vault -Name $TOTPName
+		# Timing issues, test will be flaky
+		$secret.totp() | Should -Be (& op get totp $TOTPName --vault Personal 2>$nul)
+	}
+}

--- a/tests/Get-Secret.Tests.ps1
+++ b/tests/Get-Secret.Tests.ps1
@@ -1,5 +1,5 @@
 # This assumes 1Password is already registered and unlocked
-# TODO: totp
+# TODO: Vault is manually specified for all tests to avoid https://github.com/cdhunt/SecretManagement.1Password/issues/16
 
 BeforeAll {
 	$testDetails = @{

--- a/tests/Get-Secret.Tests.ps1
+++ b/tests/Get-Secret.Tests.ps1
@@ -1,0 +1,42 @@
+# This assumes 1Password is already registered and unlocked
+
+BeforeAll {
+	$testDetails = @{
+		Vault     = 'Personal'
+		LoginName = 'TestLogin' + (Get-Random -Maximum 99999)
+		UserName  = 'TestUserName'
+		Password  = 'TestPassword'
+	}
+	
+	# Create the login, if it doesn't already exist.
+	# TODO: currently also creates if >1 exists
+	$item = & op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null
+	if ($null -eq $item) {
+		& op create item login --title $testDetails.LoginName "username=$($testDetails.UserName)" "password=$($testDetails.Password)"
+		$createdLogin = $true
+	} else {
+		Write-Warning "An item called $($testDetails.LoginName) already exists"
+	}
+}
+
+Describe 'It gets logins with vault specified' {
+	It 'Gets a login' {
+		Get-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName | Should -BeOfType PSCredential
+	}
+
+	It 'Gets the login username with vault specified' {
+		$cred = Get-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName
+		$cred.UserName | Should -Be $testDetails.UserName
+	}
+	
+	It 'Gets the login password with vault specified' {
+		$cred = Get-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName
+		$cred.Password | ConvertFrom-SecureString -AsPlainText | Should -Be $testDetails.Password
+	}
+}
+
+AfterAll {
+	if ($createdLogin) {
+		& op delete item $testDetails.LoginName
+	}
+}

--- a/tests/Get-Secret.Tests.ps1
+++ b/tests/Get-Secret.Tests.ps1
@@ -10,6 +10,10 @@ BeforeAll {
 		UserName     = 'TestUserName'
 		Password     = 'TestPassword'
 	}
+
+	Get-Module SecretManagement.1Password | Remove-Module -Force
+	Get-Module Microsoft.PowerShell.SecretManagement | Remove-Module -Force
+	Register-SecretVault -ModuleName (Join-Path $PSScriptRoot '..\SecretManagement.1Password.psd1') -Name $testDetails.Values -AllowClobber
 }
 
 Describe 'It gets logins with vault specified' {

--- a/tests/Get-Secret.Tests.ps1
+++ b/tests/Get-Secret.Tests.ps1
@@ -2,6 +2,7 @@
 # TODO: Vault is manually specified for all tests to avoid https://github.com/cdhunt/SecretManagement.1Password/issues/16
 
 BeforeAll {
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
 	$testDetails = @{
 		Vault        = 'Personal'
 		LoginName    = 'TestLogin' + (Get-Random -Maximum 99999)
@@ -18,6 +19,7 @@ Describe 'It gets logins with vault specified' {
 		$item = & op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null
 		if ($null -eq $item) {
 			& op create item login --title $testDetails.LoginName "username=$($testDetails.UserName)" "password=$($testDetails.Password)"
+			[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
 			$createdLogin = $true
 		} else {
 			Write-Warning "An item called $($testDetails.LoginName) already exists"
@@ -50,6 +52,7 @@ Describe 'It gets passwords with vault specified' {
 		$item = & op get item $testDetails.PasswordName --fields title --vault $testDetails.Vault 2>$null
 		if ($null -eq $item) {
 			& op create item password --title $testDetails.PasswordName "password=$($testDetails.Password)"
+			[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
 			$createdPassword = $true
 		} else {
 			Write-Warning "An item called $($testDetails.PasswordName) already exists"
@@ -74,6 +77,7 @@ Describe 'It gets one-time passwords with vault specified' {
 	BeforeAll {
 		# Relies on an item called TOTPTest with TOTP set up being present
 		# TODO: How to create TOTP using op?
+		[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
 		$TOTPName = 'TOTPTest'
 	}
 

--- a/tests/Get-Secret.Tests.ps1
+++ b/tests/Get-Secret.Tests.ps1
@@ -1,25 +1,29 @@
 # This assumes 1Password is already registered and unlocked
+# TODO: totp
 
 BeforeAll {
 	$testDetails = @{
-		Vault     = 'Personal'
-		LoginName = 'TestLogin' + (Get-Random -Maximum 99999)
-		UserName  = 'TestUserName'
-		Password  = 'TestPassword'
-	}
-	
-	# Create the login, if it doesn't already exist.
-	# TODO: currently also creates if >1 exists
-	$item = & op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null
-	if ($null -eq $item) {
-		& op create item login --title $testDetails.LoginName "username=$($testDetails.UserName)" "password=$($testDetails.Password)"
-		$createdLogin = $true
-	} else {
-		Write-Warning "An item called $($testDetails.LoginName) already exists"
+		Vault        = 'Personal'
+		LoginName    = 'TestLogin' + (Get-Random -Maximum 99999)
+		PasswordName = 'TestPassword' + (Get-Random -Maximum 99999)
+		UserName     = 'TestUserName'
+		Password     = 'TestPassword'
 	}
 }
 
 Describe 'It gets logins with vault specified' {
+	BeforeAll {
+		# Create the login, if it doesn't already exist.
+		# TODO: currently also creates if >1 exists
+		$item = & op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null
+		if ($null -eq $item) {
+			& op create item login --title $testDetails.LoginName "username=$($testDetails.UserName)" "password=$($testDetails.Password)"
+			$createdLogin = $true
+		} else {
+			Write-Warning "An item called $($testDetails.LoginName) already exists"
+		}
+	}
+
 	It 'Gets a login' {
 		Get-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName | Should -BeOfType PSCredential
 	}
@@ -33,10 +37,35 @@ Describe 'It gets logins with vault specified' {
 		$cred = Get-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName
 		$cred.Password | ConvertFrom-SecureString -AsPlainText | Should -Be $testDetails.Password
 	}
+
+	AfterAll {
+		if ($createdLogin) {& op delete item $testDetails.LoginName}
+	}
 }
 
-AfterAll {
-	if ($createdLogin) {
-		& op delete item $testDetails.LoginName
+Describe 'It gets passwords with vault specified' {
+	BeforeAll {
+		# Create the password, if it doesn't already exist.
+		# TODO: currently also creates if >1 exists
+		$item = & op get item $testDetails.PasswordName --fields title --vault $testDetails.Vault 2>$null
+		if ($null -eq $item) {
+			& op create item password --title $testDetails.PasswordName "password=$($testDetails.Password)"
+			$createdPassword = $true
+		} else {
+			Write-Warning "An item called $($testDetails.PasswordName) already exists"
+		}
+	}
+
+	It 'Gets a password' {
+		Get-Secret -Vault $testDetails.Vault -Name $testDetails.PasswordName | Should -BeOfType SecureString
+	}
+
+	It 'Gets the password with vault specified' {
+		Get-Secret -Vault $testDetails.Vault -Name $testDetails.PasswordName -AsPlainText | 
+		Should -Be $testDetails.Password
+	}
+
+	AfterAll {
+		if ($createdPassword) {& op delete item $testDetails.PasswordName}
 	}
 }

--- a/tests/Get-SecretInfo.Tests.ps1
+++ b/tests/Get-SecretInfo.Tests.ps1
@@ -10,6 +10,10 @@ BeforeAll {
 		UserName     = 'TestUserName'
 		Password     = 'TestPassword'
 	}
+
+	Get-Module SecretManagement.1Password | Remove-Module -Force
+	Get-Module Microsoft.PowerShell.SecretManagement | Remove-Module -Force
+	Register-SecretVault -ModuleName (Join-Path $PSScriptRoot '..\SecretManagement.1Password.psd1') -Name $testDetails.Values -AllowClobber
 }
 
 Describe 'It gets login info with vault specified' {

--- a/tests/Get-SecretInfo.Tests.ps1
+++ b/tests/Get-SecretInfo.Tests.ps1
@@ -30,14 +30,12 @@ Describe 'It gets items' {
 		}
 	}
 
-	It 'returns all items' -Skip {
-		# TODO: https://github.com/cdhunt/SecretManagement.1Password/issues/8
+	It 'returns all items' {
 		$info = Get-SecretInfo -Vault $testDetails.Vault
 		$info.Count | Should -BeGreaterOrEqual 1
 	}
 
-	it 'filters items' -skip {
-		# TODO: filtering is not yet implemented
+	it 'filters items' {
 		$info = Get-SecretInfo -Vault $testDetails.Vault -Name $testDetails.LoginName
 		$info | Should -HaveCount 1
 	}
@@ -61,8 +59,7 @@ Describe 'It gets login info with vault specified' {
 		}
 	}
 
-	It 'returns logins as PSCredentials' -Skip {
-		# TODO: https://github.com/cdhunt/SecretManagement.1Password/issues/8
+	It 'returns logins as PSCredentials' {
 		$info = Get-SecretInfo -Vault $testDetails.Vault -Name $testDetails.LoginName
 		$info | Should -BeOfType [Microsoft.PowerShell.SecretManagement.SecretInformation]
 		$info.Type | Should -Be PSCredential
@@ -87,8 +84,7 @@ Describe 'It gets password info with vault specified' {
 		}
 	}
 
-	It 'returns passwords as SecureStrings' -Skip {
-		# TODO: https://github.com/cdhunt/SecretManagement.1Password/issues/8
+	It 'returns passwords as SecureStrings' {
 		$info = Get-SecretInfo -Vault $testDetails.Vault -Name $testDetails.PasswordName
 		$info | Should -BeOfType [Microsoft.PowerShell.SecretManagement.SecretInformation]
 		$info.Type | Should -Be SecureString

--- a/tests/Get-SecretInfo.Tests.ps1
+++ b/tests/Get-SecretInfo.Tests.ps1
@@ -1,0 +1,62 @@
+# This assumes 1Password is already registered and unlocked
+# TODO: Vault is manually specified for all tests to avoid https://github.com/cdhunt/SecretManagement.1Password/issues/16
+
+BeforeAll {
+	$testDetails = @{
+		Vault        = 'Personal'
+		LoginName    = 'TestLogin' + (Get-Random -Maximum 99999)
+		PasswordName = 'TestPassword' + (Get-Random -Maximum 99999)
+		UserName     = 'TestUserName'
+		Password     = 'TestPassword'
+	}
+}
+
+Describe 'It gets login info with vault specified' {
+	BeforeAll {
+		# Create the login, if it doesn't already exist.
+		# TODO: currently also creates if >1 exists
+		$item = & op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null
+		if ($null -eq $item) {
+			& op create item login --title $testDetails.LoginName "username=$($testDetails.UserName)" "password=$($testDetails.Password)"
+			$createdLogin = $true
+		} else {
+			Write-Warning "An item called $($testDetails.LoginName) already exists"
+		}
+	}
+
+	It 'returns logins as PSCredentials' -Skip {
+		# TODO: https://github.com/cdhunt/SecretManagement.1Password/issues/8
+		$info = Get-SecretInfo -Vault $testDetails.Vault -Name $testDetails.LoginName
+		$info | Should -BeOfType [Microsoft.PowerShell.SecretManagement.SecretInformation]
+		$info.Type | Should -Be PSCredential
+	}
+
+	AfterAll {
+		if ($createdLogin) {& op delete item $testDetails.LoginName}
+	}
+}
+
+Describe 'It gets password info with vault specified' {
+	BeforeAll {
+		# Create the password, if it doesn't already exist.
+		# TODO: currently also creates if >1 exists
+		$item = & op get item $testDetails.PasswordName --fields title --vault $testDetails.Vault 2>$null
+		if ($null -eq $item) {
+			& op create item password --title $testDetails.PasswordName "password=$($testDetails.Password)"
+			$createdPassword = $true
+		} else {
+			Write-Warning "An item called $($testDetails.PasswordName) already exists"
+		}
+	}
+
+	It 'returns passwords as SecureStrings' -Skip {
+		# TODO: https://github.com/cdhunt/SecretManagement.1Password/issues/8
+		$info = Get-SecretInfo -Vault $testDetails.Vault -Name $testDetails.PasswordName
+		$info | Should -BeOfType [Microsoft.PowerShell.SecretManagement.SecretInformation]
+		$info.Type | Should -Be SecureString
+	}
+
+	AfterAll {
+		if ($createdPassword) {& op delete item $testDetails.PasswordName}
+	}
+}

--- a/tests/Get-SecretInfo.Tests.ps1
+++ b/tests/Get-SecretInfo.Tests.ps1
@@ -16,6 +16,37 @@ BeforeAll {
 	Register-SecretVault -ModuleName (Join-Path $PSScriptRoot '..\SecretManagement.1Password.psd1') -Name $testDetails.Values -AllowClobber
 }
 
+Describe 'It gets items' {
+	BeforeAll {
+		# Create the login, if it doesn't already exist.
+		# TODO: currently also creates if >1 exists
+		$item = & op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null
+		if ($null -eq $item) {
+			& op create item login --title $testDetails.LoginName "username=$($testDetails.UserName)" "password=$($testDetails.Password)"
+			[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+			$createdLogin = $true
+		} else {
+			Write-Warning "An item called $($testDetails.LoginName) already exists"
+		}
+	}
+
+	It 'returns all items' -Skip {
+		# TODO: https://github.com/cdhunt/SecretManagement.1Password/issues/8
+		$info = Get-SecretInfo -Vault $testDetails.Vault
+		$info.Count | Should -BeGreaterOrEqual 1
+	}
+
+	it 'filters items' -skip {
+		# TODO: filtering is not yet implemented
+		$info = Get-SecretInfo -Vault $testDetails.Vault -Name $testDetails.LoginName
+		$info | Should -HaveCount 1
+	}
+
+	AfterAll {
+		if ($createdLogin) {& op delete item $testDetails.LoginName}
+	}
+}
+
 Describe 'It gets login info with vault specified' {
 	BeforeAll {
 		# Create the login, if it doesn't already exist.

--- a/tests/Get-SecretInfo.Tests.ps1
+++ b/tests/Get-SecretInfo.Tests.ps1
@@ -2,6 +2,7 @@
 # TODO: Vault is manually specified for all tests to avoid https://github.com/cdhunt/SecretManagement.1Password/issues/16
 
 BeforeAll {
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
 	$testDetails = @{
 		Vault        = 'Personal'
 		LoginName    = 'TestLogin' + (Get-Random -Maximum 99999)
@@ -18,6 +19,7 @@ Describe 'It gets login info with vault specified' {
 		$item = & op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null
 		if ($null -eq $item) {
 			& op create item login --title $testDetails.LoginName "username=$($testDetails.UserName)" "password=$($testDetails.Password)"
+			[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
 			$createdLogin = $true
 		} else {
 			Write-Warning "An item called $($testDetails.LoginName) already exists"
@@ -43,6 +45,7 @@ Describe 'It gets password info with vault specified' {
 		$item = & op get item $testDetails.PasswordName --fields title --vault $testDetails.Vault 2>$null
 		if ($null -eq $item) {
 			& op create item password --title $testDetails.PasswordName "password=$($testDetails.Password)"
+			[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
 			$createdPassword = $true
 		} else {
 			Write-Warning "An item called $($testDetails.PasswordName) already exists"

--- a/tests/Remove-Secret.Tests.ps1
+++ b/tests/Remove-Secret.Tests.ps1
@@ -9,6 +9,10 @@ BeforeDiscovery {
 		Password  = 'TestPassword'
 	}
 
+	Get-Module SecretManagement.1Password | Remove-Module -Force
+	Get-Module Microsoft.PowerShell.SecretManagement | Remove-Module -Force
+	Register-SecretVault -ModuleName (Join-Path $PSScriptRoot '..\SecretManagement.1Password.psd1') -Name $testDetails.Values -AllowClobber
+
 	# Create the login, if it doesn't already exist.
 	# TODO: currently also creates if >1 exists
 	$item = & op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null
@@ -23,11 +27,11 @@ BeforeDiscovery {
 }
 
 Describe 'It removes items' {
-	It 'It removes an item with vault specified' -Skip:($createdLogin -ne $true) -ForEach @(@{LoginName = $testDetails.LoginName}) {
+	It 'It removes an item with vault specified' -Skip:($createdLogin -ne $true) -ForEach @($testDetails) {
 		# Skip the test if we did not create the login item
 		# Use -ForEach to get the same $LoginName value as in BeforeDiscovery
-		Remove-Secret -Vault $testDetails.Vault -Name $LoginName
+		Remove-Secret -Vault $Vault -Name $LoginName
 		# Confirm the item no longer exists
-		& op get item $LoginName --fields title --vault $testDetails.Vault 2>$null | Should -BeNullOrEmpty
+		& op get item $LoginName --fields title --vault $Vault 2>$null | Should -BeNullOrEmpty
 	}
 }

--- a/tests/Remove-Secret.Tests.ps1
+++ b/tests/Remove-Secret.Tests.ps1
@@ -1,0 +1,31 @@
+# This assumes 1Password is already registered and unlocked
+# TODO: Vault is manually specified for all tests to avoid https://github.com/cdhunt/SecretManagement.1Password/issues/16
+
+BeforeDiscovery {
+	$testDetails = @{
+		Vault     = 'Personal'
+		LoginName = 'TestLogin' + (Get-Random -Maximum 99999)
+		UserName  = 'TestUserName'
+		Password  = 'TestPassword'
+	}
+
+	# Create the login, if it doesn't already exist.
+	# TODO: currently also creates if >1 exists
+	$item = & op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null
+	if ($null -eq $item) {
+		& op create item login --title $testDetails.LoginName "username=$($testDetails.UserName)" "password=$($testDetails.Password)"
+		$createdLogin = $true
+	} else {
+		Write-Warning "An item called $($testDetails.LoginName) already exists. Remove-Item test will be skipped."
+		$createdLogin = $false
+	}
+}
+
+Describe 'It removes items' {
+	It 'It removes an item with vault specified' -Skip:($createdLogin -ne $true) {
+		# Skip the test if we did not create the login item
+		Remove-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName
+		# Confirm the item no longer exists
+		& op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null | Should -BeNullOrEmpty
+	}
+}

--- a/tests/Remove-Secret.Tests.ps1
+++ b/tests/Remove-Secret.Tests.ps1
@@ -22,10 +22,11 @@ BeforeDiscovery {
 }
 
 Describe 'It removes items' {
-	It 'It removes an item with vault specified' -Skip:($createdLogin -ne $true) {
+	It 'It removes an item with vault specified' -Skip:($createdLogin -ne $true) -ForEach @(@{LoginName = $testDetails.LoginName}) {
 		# Skip the test if we did not create the login item
-		Remove-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName
+		# Use -ForEach to get the same $LoginName value as in BeforeDiscovery
+		Remove-Secret -Vault $testDetails.Vault -Name $LoginName
 		# Confirm the item no longer exists
-		& op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null | Should -BeNullOrEmpty
+		& op get item $LoginName --fields title --vault $testDetails.Vault 2>$null | Should -BeNullOrEmpty
 	}
 }

--- a/tests/Remove-Secret.Tests.ps1
+++ b/tests/Remove-Secret.Tests.ps1
@@ -14,6 +14,7 @@ BeforeDiscovery {
 	$item = & op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null
 	if ($null -eq $item) {
 		& op create item login --title $testDetails.LoginName "username=$($testDetails.UserName)" "password=$($testDetails.Password)"
+		[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
 		$createdLogin = $true
 	} else {
 		Write-Warning "An item called $($testDetails.LoginName) already exists. Remove-Item test will be skipped."

--- a/tests/Set-Secret.Tests.ps1
+++ b/tests/Set-Secret.Tests.ps1
@@ -1,4 +1,5 @@
 # This assumes 1Password is already registered and unlocked
+# TODO: Vault is manually specified for all tests to avoid https://github.com/cdhunt/SecretManagement.1Password/issues/16
 
 BeforeAll {
 	$testDetails = @{

--- a/tests/Set-Secret.Tests.ps1
+++ b/tests/Set-Secret.Tests.ps1
@@ -9,6 +9,10 @@ BeforeAll {
 		UserName  = 'TestUserName'
 		Password  = 'TestPassword'
 	}
+
+	Get-Module SecretManagement.1Password | Remove-Module -Force
+	Get-Module Microsoft.PowerShell.SecretManagement | Remove-Module -Force
+	Register-SecretVault -ModuleName (Join-Path $PSScriptRoot '..\SecretManagement.1Password.psd1') -Name $testDetails.Values -AllowClobber
 }
 
 Describe 'It updates items that already exist' {

--- a/tests/Set-Secret.Tests.ps1
+++ b/tests/Set-Secret.Tests.ps1
@@ -22,8 +22,14 @@ Describe 'It updates items that already exist' {
 		}
 	}
 
-	It 'Sets the password from a value type with vault specified' {
+	It 'Sets the password from an int value type with vault specified' {
 		$testvalue = 123456
+		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret $testvalue
+		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
+	}
+
+	It 'Sets the password from a char value type with vault specified' {
+		$testvalue = [char]'a'
 		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret $testvalue
 		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
 	}
@@ -67,9 +73,15 @@ Describe 'It creates items' {
 		}
 	}
 
-	It 'Sets the password from a value type with vault specified' -Skip {
+	It 'Sets the password from an int value type with vault specified' -Skip {
 		# TODO: does not work, appears to be an issue in op: json: cannot unmarshal number into Go struct field _passwordItemDetails.password of type string
 		$testvalue = 123456
+		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret $testvalue
+		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
+	}
+
+	It 'Sets the password from a char value type with vault specified' {
+		$testvalue = [char]'a'
 		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret $testvalue
 		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
 	}

--- a/tests/Set-Secret.Tests.ps1
+++ b/tests/Set-Secret.Tests.ps1
@@ -54,8 +54,7 @@ Describe 'It updates items that already exist' {
 		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
 	}
 	
-	It 'Sets the password from a PSCredential with vault specified' -Skip {
-		# TODO: Updating an existing item using a PSCredential does not currently work
+	It 'Sets the password from a PSCredential with vault specified' {
 		$testvalue = 'PSCredential Password!'
 		$testusername = 'PSCredential Username'
 		$cred = [pscredential]::new($testusername, ($testvalue | ConvertTo-SecureString -AsPlainText -Force))

--- a/tests/Set-Secret.Tests.ps1
+++ b/tests/Set-Secret.Tests.ps1
@@ -51,9 +51,11 @@ Describe 'It updates items that already exist' {
 	It 'Sets the password from a PSCredential with vault specified' -Skip {
 		# TODO: Updating an existing item using a PSCredential does not currently work
 		$testvalue = 'PSCredential Password!'
-		$cred = [pscredential]::new('PSCredential Username', ($testvalue | ConvertTo-SecureString -AsPlainText -Force))
+		$testusername = 'PSCredential Username'
+		$cred = [pscredential]::new($testusername, ($testvalue | ConvertTo-SecureString -AsPlainText -Force))
 		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret $cred
 		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
+		& op get item $testDetails.LoginName --fields username --vault $testDetails.Vault | Should -Be $testusername
 	}
 	
 	AfterAll {
@@ -100,12 +102,14 @@ Describe 'It creates items' {
 		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
 	}
 	
-	It 'Sets the password from a PSCredential with vault specified' {
+	It 'Sets the username and password from a PSCredential with vault specified' {
 		# TODO: Updating an existing item using a PSCredential does not currently work
 		$testvalue = 'PSCredential Password!'
-		$cred = [pscredential]::new('PSCredential Username', ($testvalue | ConvertTo-SecureString -AsPlainText -Force))
+		$testusername = 'PSCredential Username'
+		$cred = [pscredential]::new($testusername, ($testvalue | ConvertTo-SecureString -AsPlainText -Force))
 		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret $cred
 		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
+		& op get item $testDetails.LoginName --fields username --vault $testDetails.Vault | Should -Be $testusername
 	}
 	
 	AfterEach {

--- a/tests/Set-Secret.Tests.ps1
+++ b/tests/Set-Secret.Tests.ps1
@@ -29,7 +29,7 @@ Describe 'It updates items that already exist' {
 	}
 
 	It 'Sets the password from a string with vault specified' -Skip {
-		# TODO: Using a string with Set-Secret does not currently work
+		# TODO: Using a string with Set-Secret does not currently work https://github.com/cdhunt/SecretManagement.1Password/issues/17
 		$testvalue = 'String Password!'
 		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret $testvalue
 		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
@@ -50,6 +50,52 @@ Describe 'It updates items that already exist' {
 	}
 	
 	AfterAll {
+		if ($createdLogin) {
+			& op delete item $testDetails.LoginName
+		}
+	}
+}
+
+Describe 'It creates items' {
+	BeforeEach {
+		# TODO: currently also creates if >1 exists
+		$item = & op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null
+		if ($null -eq $item) {
+			$createdLogin = $true
+		} else {
+			Write-Warning "An item called $($testDetails.LoginName) already exists"
+		}
+	}
+
+	It 'Sets the password from a value type with vault specified' -Skip {
+		# TODO: does not work, appears to be an issue in op: json: cannot unmarshal number into Go struct field _passwordItemDetails.password of type string
+		$testvalue = 123456
+		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret $testvalue
+		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
+	}
+
+	It 'Sets the password from a string with vault specified' -Skip {
+		# TODO: Using a string with Set-Secret does not currently work https://github.com/cdhunt/SecretManagement.1Password/issues/17
+		$testvalue = 'String Password!'
+		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret $testvalue
+		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
+	}
+	
+	It 'Sets the password from a SecureString with vault specified' {
+		$testvalue = 'SecureString Password!'
+		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret ($testvalue | ConvertTo-SecureString -AsPlainText -Force)
+		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
+	}
+	
+	It 'Sets the password from a PSCredential with vault specified' {
+		# TODO: Updating an existing item using a PSCredential does not currently work
+		$testvalue = 'PSCredential Password!'
+		$cred = [pscredential]::new('PSCredential Username', ($testvalue | ConvertTo-SecureString -AsPlainText -Force))
+		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret $cred
+		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
+	}
+	
+	AfterEach {
 		if ($createdLogin) {
 			& op delete item $testDetails.LoginName
 		}

--- a/tests/Set-Secret.Tests.ps1
+++ b/tests/Set-Secret.Tests.ps1
@@ -41,8 +41,7 @@ Describe 'It updates items that already exist' {
 		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
 	}
 
-	It 'Sets the password from a string with vault specified' -Skip {
-		# TODO: Using a string with Set-Secret does not currently work https://github.com/cdhunt/SecretManagement.1Password/issues/17
+	It 'Sets the password from a string with vault specified' {
 		$testvalue = 'String Password!'
 		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret $testvalue
 		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
@@ -95,8 +94,7 @@ Describe 'It creates items' {
 		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
 	}
 
-	It 'Sets the password from a string with vault specified' -Skip {
-		# TODO: Using a string with Set-Secret does not currently work https://github.com/cdhunt/SecretManagement.1Password/issues/17
+	It 'Sets the password from a string with vault specified' {
 		$testvalue = 'String Password!'
 		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret $testvalue
 		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue

--- a/tests/Set-Secret.Tests.ps1
+++ b/tests/Set-Secret.Tests.ps1
@@ -1,0 +1,57 @@
+# This assumes 1Password is already registered and unlocked
+
+BeforeAll {
+	$testDetails = @{
+		Vault     = 'Personal'
+		LoginName = 'TestLogin' + (Get-Random -Maximum 99999)
+		UserName  = 'TestUserName'
+		Password  = 'TestPassword'
+	}
+}
+
+Describe 'It updates items that already exist' {
+	BeforeAll {
+		# Create the login, if it doesn't already exist.
+		# TODO: currently also creates if >1 exists
+		$item = & op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null
+		if ($null -eq $item) {
+			& op create item login --title $testDetails.LoginName "username=$($testDetails.UserName)" "password=$($testDetails.Password)"
+			$createdLogin = $true
+		} else {
+			Write-Warning "An item called $($testDetails.LoginName) already exists"
+		}
+	}
+
+	It 'Sets the password from a value type with vault specified' {
+		$testvalue = 123456
+		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret $testvalue
+		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
+	}
+
+	It 'Sets the password from a string with vault specified' -Skip {
+		# TODO: Using a string with Set-Secret does not currently work
+		$testvalue = 'String Password!'
+		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret $testvalue
+		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
+	}
+	
+	It 'Sets the password from a SecureString with vault specified' {
+		$testvalue = 'SecureString Password!'
+		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret ($testvalue | ConvertTo-SecureString -AsPlainText -Force)
+		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
+	}
+	
+	It 'Sets the password from a PSCredential with vault specified' -Skip {
+		# TODO: Updating an existing item using a PSCredential does not currently work
+		$testvalue = 'PSCredential Password!'
+		$cred = [pscredential]::new('PSCredential Username', ($testvalue | ConvertTo-SecureString -AsPlainText -Force))
+		Set-Secret -Vault $testDetails.Vault -Name $testDetails.LoginName -Secret $cred
+		& op get item $testDetails.LoginName --fields password --vault $testDetails.Vault | Should -Be $testvalue
+	}
+	
+	AfterAll {
+		if ($createdLogin) {
+			& op delete item $testDetails.LoginName
+		}
+	}
+}

--- a/tests/Set-Secret.Tests.ps1
+++ b/tests/Set-Secret.Tests.ps1
@@ -2,6 +2,7 @@
 # TODO: Vault is manually specified for all tests to avoid https://github.com/cdhunt/SecretManagement.1Password/issues/16
 
 BeforeAll {
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
 	$testDetails = @{
 		Vault     = 'Personal'
 		LoginName = 'TestLogin' + (Get-Random -Maximum 99999)
@@ -17,6 +18,7 @@ Describe 'It updates items that already exist' {
 		$item = & op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null
 		if ($null -eq $item) {
 			& op create item login --title $testDetails.LoginName "username=$($testDetails.UserName)" "password=$($testDetails.Password)"
+			[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
 			$createdLogin = $true
 		} else {
 			Write-Warning "An item called $($testDetails.LoginName) already exists"
@@ -70,6 +72,7 @@ Describe 'It creates items' {
 		# TODO: currently also creates if >1 exists
 		$item = & op get item $testDetails.LoginName --fields title --vault $testDetails.Vault 2>$null
 		if ($null -eq $item) {
+			[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
 			$createdLogin = $true
 		} else {
 			Write-Warning "An item called $($testDetails.LoginName) already exists"


### PR DESCRIPTION
They currently rely on the vault being signed in/unlocked/etc, but it's enough for `Invoke-Pester` to work.

Most of the ideas in https://github.com/cdhunt/SecretManagement.1Password/issues/12 are implemented- I left byte[] and hashtable tests for `Set-Secret` out since they hit the same issue as String and would be virtually identical.