### PR TITLE
Fix Set-Secret with strings

### DIFF
--- a/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
+++ b/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
@@ -152,7 +152,7 @@ function Set-Secret {
 
     Write-Verbose "Secret type [$($Secret.GetType().Name)]"
     switch ($Secret.GetType()) {
-        { $_.IsValueType } {
+        { $_.Name -eq 'String' -or $_.IsValueType } {
             $category = "Password"
             Write-Verbose "Processing [string] as $category"
             $commandArgs.Add($verb) | Out-Null


### PR DESCRIPTION
Strings aren't a value type, so didn't match any cases, and default case doesn't do anything, so op errors.