### PR TITLE
Fix key case error in Get-SecretInfo

### DIFF
--- a/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
+++ b/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
@@ -60,7 +60,8 @@ function Get-SecretInfo {
         [hashtable] $AdditionalParameters
     )
 
-    $items = & op list items --categories Login,Password --vault $VaultName | ConvertFrom-Json
+    $json = & op list items --categories Login,Password --vault $VaultName
+    $items = $json -replace 'b5UserUUID','B5UserUUID' | ConvertFrom-Json
 
     $keyList = [Collections.ArrayList]::new()
 


### PR DESCRIPTION
`Get-SecretInfo` can error with `Get-SecretInfo: Cannot convert the JSON string because it contains keys with different casing. Please use the -AsHashTable switch instead. The key that was attempted to be added to the existing key 'B5UserUUID' was 'b5UserUUID'.`

`ConvertFrom-Json -AsHashtable` isn't available in 5.1, so fix the case.