### PR TITLE
Implemented metadata on Get-SecretInfo

### DIFF
--- a/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
+++ b/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
@@ -176,6 +176,12 @@ function Get-SecretInfo {
                 'PASSWORD' { [SecretType]::SecureString }
                 Default { [SecretType]::Unknown }
             }
+            
+            $metadata = @{
+                version = $item.version
+                created_at = Get-Date $item.created_at
+                updated_at = Get-Date $item.updated_at
+            }
 
             Write-Verbose $item.title
             
@@ -185,7 +191,7 @@ function Get-SecretInfo {
             # See: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.secretmanagement/get-secret?view=ps-modules#-inputobject
             $keyList.Add( `
                 $(($item.title).ToLower()), `
-                [SecretInformation]::new($item.title, $type, $($VaultName)) `
+                [SecretInformation]::new($item.title, $type, $($VaultName), $metadata) `
             );
         }
     }

--- a/tests/Get-SecretInfo.Tests.ps1
+++ b/tests/Get-SecretInfo.Tests.ps1
@@ -42,6 +42,11 @@ Describe 'It gets items' {
 		$info | Should -HaveCount 1
 	}
 
+	it 'includes metadata' {
+		$info = Get-SecretInfo -Vault "$($testDetails.Vault)"
+		$info.Metadata.Count | Should -BeGreaterOrEqual 3
+	}
+
 	AfterAll {
 		if ($createdLogin) {& op item delete "$($testDetails.LoginName)"}
 	}


### PR DESCRIPTION
I noticed that when using `Get-SecretInfo` a Metadata attribute is included but empty. When looking at the code I found the Metadata field is part of `Get-SecretInfo` and `Set-SecretInfo` in [SecretManagement](https://github.com/PowerShell/SecretManagement/tree/main) but was not implemented in this project. 1Password includes version number, created datetime, and updated datetime with the `op get list` command for every password. I have modified `Get-SecretInfo` to include these details in the Metadata property. I have used a hashtable for Metadata as that is the required type according to the SecretManagement documentation.

I did not bother implementing this in `Set-SecretInfo` as these 3 values all update automatically, so it wouldn't make sense with that command. 

A new test for the Metadata is included.

**Before:**
```
$passwords = Get-SecretInfo -Vault '1Password: Test'
$passwords[0] | fl *

Name      : Test Password
Type      : PSCredential
VaultName : 1Password: Test
Metadata  :
```

**After:**
```
$passwords = Get-SecretInfo -Vault '1Password: Test'
$passwords[0] | fl *

Name      : Test Password
Type      : PSCredential
VaultName : 1Password: Test
Metadata  : {[created_at, 2025-02-13 9:05:02 AM], [updated_at, 2025-02-14 4:10:11 PM], [version, 2]}
```