### PR TITLE
Bug Fix: Quote parameters to prevent errors when they contain whitespaces

### DIFF
--- a/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psd1
+++ b/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion     = '2.0.0.0'
+    ModuleVersion     = '2.0.0.1'
     RootModule = 'SecretManagement.1Password.Extension.psm1'
     FunctionsToExport = @('Get-Secret','Get-SecretInfo','Test-SecretVault','Set-Secret','Remove-Secret')
 }

--- a/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
+++ b/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
@@ -142,10 +142,10 @@ function Get-SecretInfo {
     $commandArgs = [System.Collections.ArrayList]::new();
     $commandArgs.AddRange(@('item', 'list'));
     if ($VaultParameters.AccountName) {
-        $commandArgs.AddRange(@('--account', "$($VaultParameters.AccountName)"));
+        $commandArgs.AddRange(@('--account', """$($VaultParameters.AccountName)"""));
     }
     if ($VaultParameters.OPVault) {
-        $commandArgs.AddRange(@('--vault', "$($VaultParameters.OPVault)"));
+        $commandArgs.AddRange(@('--vault', """$($VaultParameters.OPVault)"""));
     }
     $commandArgs.AddRange(@('--categories', '"LOGIN,PASSWORD"', '--format', 'json'));
     $result = Invoke-OpCommand $commandArgs;
@@ -226,10 +226,10 @@ function Get-Secret {
     $commandArgs = [System.Collections.ArrayList]::new();
     $commandArgs.AddRange(@('item', 'get', """$($Name)"""));
     if ($VaultParameters.AccountName) {
-        $commandArgs.AddRange(@('--account', "$($VaultParameters.AccountName)"));
+        $commandArgs.AddRange(@('--account', """$($VaultParameters.AccountName)"""));
     }
     if ($VaultParameters.OPVault) {
-        $commandArgs.AddRange(@('--vault', "$($VaultParameters.OPVault)"));
+        $commandArgs.AddRange(@('--vault', """$($VaultParameters.OPVault)"""));
     }
     $commandArgs.AddRange(@('--format', 'json'));
     $result = Invoke-OpCommand $commandArgs;
@@ -331,10 +331,10 @@ function Set-Secret {
     $commandArgs = [System.Collections.ArrayList]::new();
     $commandArgs.AddRange(@('item', 'get', """$($Name)"""));
     if ($VaultParameters.AccountName) {
-        $commandArgs.AddRange(@('--account', "$($VaultParameters.AccountName)"));
+        $commandArgs.AddRange(@('--account', """$($VaultParameters.AccountName)"""));
     }
     if ($VaultParameters.OPVault) {
-        $commandArgs.AddRange(@('--vault', "$($VaultParameters.OPVault)"));
+        $commandArgs.AddRange(@('--vault', """$($VaultParameters.OPVault)"""));
     }
     $commandArgs.AddRange(@('--format', 'json'));
     $result = Invoke-OpCommand $commandArgs;
@@ -354,10 +354,10 @@ function Set-Secret {
     $commandArgs = [System.Collections.ArrayList]::new();
     $commandArgs.AddRange(@('item', $verb));
     if ($VaultParameters.AccountName) {
-        $commandArgs.AddRange(@('--account', "$($VaultParameters.AccountName)"));
+        $commandArgs.AddRange(@('--account', """$($VaultParameters.AccountName)"""));
     }
     if ($VaultParameters.OPVault) {
-        $commandArgs.AddRange(@('--vault', "$($VaultParameters.OPVault)"));
+        $commandArgs.AddRange(@('--vault', """$($VaultParameters.OPVault)"""));
     }
     $commandArgs.AddRange(@('--format', 'json'));
 
@@ -477,10 +477,10 @@ function Remove-Secret {
     $commandArgs = [System.Collections.ArrayList]::new();
     $commandArgs.AddRange(@('item', 'delete', """$($Name)"""));
     if ($VaultParameters.AccountName) {
-        $commandArgs.AddRange(@('--account', "$($VaultParameters.AccountName)"));
+        $commandArgs.AddRange(@('--account', """$($VaultParameters.AccountName)"""));
     }
     if ($VaultParameters.OPVault) {
-        $commandArgs.AddRange(@('--vault', "$($VaultParameters.OPVault)"));
+        $commandArgs.AddRange(@('--vault', """$($VaultParameters.OPVault)"""));
     }
     $commandArgs.Add("--archive") | Out-Null
     Write-Verbose ($commandArgs -join ' ')

--- a/SecretManagement.1Password.psd1
+++ b/SecretManagement.1Password.psd1
@@ -12,7 +12,7 @@
     # RootModule = ''
 
     # Version number of this module.
-    ModuleVersion     = '1.0.0'
+    ModuleVersion     = '1.0.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
This PR contains a fix that prevent errors when parameters contain whitespaces. More specifically, when the name of a vault in 1Password contains whitespaces, the API requests that target that vault fail because the 1Password CLI see each word as a parameter. This fix surrounds all params with double quotations to prevent this issue going forward.

The release numbers are also updated to allow the PowerShell Gallery to identify the latest version.