### PR TITLE
Hide black window shown when the 1Password CLI is called

### DIFF
--- a/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psd1
+++ b/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion     = '2.0.0.1'
+    ModuleVersion     = '2.0.0.2'
     RootModule = 'SecretManagement.1Password.Extension.psm1'
     FunctionsToExport = @('Get-Secret','Get-SecretInfo','Test-SecretVault','Set-Secret','Remove-Secret')
 }

--- a/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
+++ b/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psm1
@@ -29,6 +29,8 @@ Argument list to be passed to the 1Password CLI console application.
     $pinfo.RedirectStandardError = $true;
     $pinfo.RedirectStandardOutput = $true;
     $pinfo.UseShellExecute = $false;
+    $pinfo.CreateNoWindow = $true;
+    $pinfo.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Hidden;
     $pinfo.Arguments = ($ArgumentList -join " ");
     $p = New-Object System.Diagnostics.Process;
     $p.StartInfo = $pinfo;

--- a/SecretManagement.1Password.psd1
+++ b/SecretManagement.1Password.psd1
@@ -12,7 +12,7 @@
     # RootModule = ''
 
     # Version number of this module.
-    ModuleVersion     = '1.0.1'
+    ModuleVersion     = '1.0.2'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()


### PR DESCRIPTION
Hide the command prompt (black) window shown when the 1Password CLI API is called. This process should be transparent to the end user.