### PR TITLE
Made the extension module work on MacOS

### DIFF
--- a/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psd1
+++ b/SecretManagement.1Password.Extension/SecretManagement.1Password.Extension.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion     = '2.0.0.1'
+    ModuleVersion     = '2.0.0.2'
     RootModule = 'SecretManagement.1Password.Extension.psm1'
     FunctionsToExport = @('Get-Secret','Get-SecretInfo','Test-SecretVault','Set-Secret','Remove-Secret')
 }

--- a/tests/Get-Secret.Tests.ps1
+++ b/tests/Get-Secret.Tests.ps1
@@ -43,7 +43,9 @@ Describe 'It gets logins with vault specified' {
 	
 	It 'Gets the login password with vault specified' {
 		$cred = Get-Secret -Vault "$($testDetails.Vault)" -Name "$($testDetails.LoginName)"
-		$([System.Runtime.InteropServices.Marshal]::PtrToStringAuto( `
+		# using PtrToStringBSTR ensures uniform results across platforms
+		# https://stackoverflow.com/questions/60404847/are-you-able-to-use-ptrtostringauto-to-decrypt-a-secure-string-in-powershell-7-o
+		$([System.Runtime.InteropServices.Marshal]::PtrToStringBSTR( `
 			[System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($cred.Password))) | Should -Be $testDetails.Password
 	}
 


### PR DESCRIPTION
Hello! Genuinely interested to make this module work on MacOS as I have a usecase for it

The list of changes as per the commit message:
* replaced PtrToStringAuto with PtrToStringBSTR for cross-platform compatibility (reason: https://stackoverflow.com/questions/60404847/are-you-able-to-use-ptrtostringauto-to-decrypt-a-secure-string-in-powershell-7-o)
* added IsWindows/$PSVersionTable check to avoid hardcoding op.exe
* PtrToStringBSTR is used in the tests too - tests pass
* bumped extension module version
* also accidentlly may have ran Powershell formatter on the whole psm1 file

Tests were ran under MacOS Sequoia 15.5:
```
> $PSVersionTable

Name                           Value
----                           -----
PSVersion                      7.5.2
PSEdition                      Core
GitCommitId                    7.5.2
OS                             Darwin 24.5.0 Darwin Kernel Version 24.5.0: Tue Apr 22 19:54:33 PDT 2025; root:xnu-11417.121.6~2/RELEASE_ARM64_T8122
Platform                       Unix
PSCompatibleVersions           {1.0, 2.0, 3.0, 4.0…}
PSRemotingProtocolVersion      2.3
SerializationVersion           1.1.0.1
WSManStackVersion              3.0
```

Test results:
```
> Invoke-Pester

Starting discovery in 5 files.
Discovery found 33 tests in 97ms.
Running tests.
[+] /Users/<...>/SecretManagement.1Password/tests/Get-Secret.Tests.ps1 29.15s (28.94s|150ms)
[+] /Users/<...>/SecretManagement.1Password/tests/Get-SecretInfo.Tests.ps1 20.35s (20.3s|43ms)
[+] /Users/<...>/SecretManagement.1Password/tests/Remove-Secret.Tests.ps1 8.37s (8.34s|21ms)
[+] /Users/<...>/SecretManagement.1Password/tests/Set-Secret.Tests.ps1 86.5s (86.45s|42ms)
[+] /Users/<...>/SecretManagement.1Password/tests/Test-SecretVault.Tests.ps1 4.5s (4.44s|43ms)
Tests completed in 148.88s
Tests Passed: 30, Failed: 0, Skipped: 3, Inconclusive: 0, NotRun: 0
```

@cdhunt if you want anything else to be done for this to be merged, I'll be glad to help out